### PR TITLE
Refactor server setup to use uv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -50,10 +50,19 @@ Key features:
 A simple HTTP server is required to serve the HTML and JS files.
 
 ### Prerequisites
-- Node.js or Python installed on your machine
+- [uv](https://docs.astral.sh/uv/) installed on your machine (recommended)
 - Two USB or Bluetooth gamepads supported by your browser
 
-### Start a Local Server
+### Start a Local Server (Recommended: uv)
+
+The easiest way to run the server is with `uv`:
+
+```bash
+cd dot-dash
+uv run server.py
+```
+
+### Alternative Methods
 
 1. **Using Python 3** (no install required):
 
@@ -70,23 +79,9 @@ A simple HTTP server is required to serve the HTML and JS files.
    http-server -p 8000
    ```
 
-3. **Access the game**: Open http://localhost:8000 in your web browser.
+### Access the Game
 
----
-
-## 🛠️ Server (Optional Python Backend)
-
-The `server.py` script can serve static files with optional logging:
-
-```bash
-# Install dependencies (if any):
-pip install flask
-
-# Run the server
-python server.py
-```
-
-Visit http://localhost:5000 to play. Adjust port in `server.py` if needed.
+Open http://localhost:8000 in your web browser.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "dot-dash"
+version = "1.0.0"
+description = "A retro-inspired two-player arcade game"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = []

--- a/server.py
+++ b/server.py
@@ -3,8 +3,13 @@ import socketserver
 
 PORT = 8000
 
-Handler = http.server.SimpleHTTPRequestHandler
-httpd = socketserver.TCPServer(("", PORT), Handler)
 
-print(f"Serving at http://localhost:{PORT}")
-httpd.serve_forever()
+def main():
+    handler = http.server.SimpleHTTPRequestHandler
+    with socketserver.TCPServer(("", PORT), handler) as httpd:
+        print(f"Serving at http://localhost:{PORT}")
+        httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 1
+requires-python = ">=3.8"
+
+[[package]]
+name = "dot-dash"
+version = "1.0.0"
+source = { virtual = "." }


### PR DESCRIPTION
## Summary
- Added `pyproject.toml` for uv package management
- Updated `server.py` with proper `main()` function and context manager
- Updated README with uv setup instructions as the primary method
- Added `.gitignore` for Python/uv artifacts

## Test plan
- [ ] Run `uv run server.py` and verify server starts at http://localhost:8000
- [ ] Verify game loads correctly in browser

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)